### PR TITLE
fix: upstart for ubuntu

### DIFF
--- a/add-upstart-ems
+++ b/add-upstart-ems
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 install_ems_on_ubuntu () {
-     cp /opt/openbaton/ems/upstart/openbaton-ems-debian /etc/init.d/openbaton-ems
+     cp /usr/local/lib/python2.7/dist-packages/opt/openbaton/ems/upstart/openbaton-ems-debian /etc/init.d/openbaton-ems /etc/init.d/openbaton-ems
      chmod +x /etc/init.d/openbaton-ems
      update-rc.d openbaton-ems defaults
 }


### PR DESCRIPTION
it seems that trying to copy data-files outside of python is inconistent, the upstart script was modified to pull the files from inside relative path